### PR TITLE
Review changes for element parameter

### DIFF
--- a/src/Gantt.js
+++ b/src/Gantt.js
@@ -73,7 +73,7 @@ export default function Gantt(element, tasks, config) {
 		else {
 		    throw new TypeError("Frappé Gantt only supports usage of a string CSS selector or SVG DOM element for the 'element' parameter to create a gantt chart.");
 		}
-		
+
 		self._tasks = tasks;
 
 		self._bars = [];
@@ -272,7 +272,7 @@ export default function Gantt(element, tasks, config) {
 	}
 
 	function set_scroll_position() {
-			let parent_element = self.element.parentElement;
+		const parent_element = self.element.parentElement;
 
 		if(!parent_element) return;
 

--- a/src/Gantt.js
+++ b/src/Gantt.js
@@ -1,7 +1,7 @@
 /* global moment, Snap */
 /**
  * Gantt:
- * 	element: querySelector string, required
+ * 	element: querySelector string or HTML DOM element, required
  * 	tasks: array of tasks, required
  *   task: { id, name, start, end, progress, dependencies, custom_class }
  * 	config: configuration options, optional
@@ -69,6 +69,9 @@ export default function Gantt(element, tasks, config) {
 		}
 		else if (element instanceof SVGElement) {
 		    self.element = element;
+		}
+		else if (element instanceof HTMLElement) {
+		    self.element = element.querySelector('svg');
 		}
 		else {
 		    throw new TypeError("Frappé Gantt only supports usage of a string CSS selector or SVG DOM element for the 'element' parameter to create a gantt chart.");

--- a/src/Gantt.js
+++ b/src/Gantt.js
@@ -1,7 +1,7 @@
 /* global moment, Snap */
 /**
  * Gantt:
- * 	element: querySelector string or HTML DOM element, required
+ * 	element: querySelector string, HTML DOM or SVG DOM element, required
  * 	tasks: array of tasks, required
  *   task: { id, name, start, end, progress, dependencies, custom_class }
  * 	config: configuration options, optional
@@ -74,7 +74,7 @@ export default function Gantt(element, tasks, config) {
 		    self.element = element.querySelector('svg');
 		}
 		else {
-		    throw new TypeError("Frappé Gantt only supports usage of a string CSS selector or SVG DOM element for the 'element' parameter to create a gantt chart.");
+		    throw new TypeError("Frappé Gantt only supports usage of a string CSS selector, HTML DOM element or SVG DOM element for the 'element' parameter to create a gantt chart.");
 		}
 
 		self._tasks = tasks;


### PR DESCRIPTION
Hi there,

I made a small change which I believe will make Frappé Gantt more useful.

According to http://snapsvg.io/docs/, the Snap constructor supports usage of a string css selector or a DOM SVG element, thus Frappé Gantt was updated to support checking for both types of elements and the set_scroll_position updated to use the element (without querying it).

Please feel free to review the changes I have made and if they make sense to be included into the core project.

Kind regards and tsikitsiky lava (always smile in Malagasy)
Matthew