### PR TITLE
Remove letter-spacing to display Arabic properly

### DIFF
--- a/src/gantt.scss
+++ b/src/gantt.scss
@@ -72,7 +72,6 @@ $handle-color: #ddd;
 		text-anchor: middle;
 		font-size: 12px;
 		font-weight: lighter;
-		letter-spacing: 0.8px;
 
 		&.big {
 			fill: $text-light;


### PR DESCRIPTION
Arabic is not displayed correctly when letter-spacing is used. E.g. [this issue](https://github.com/frappe/frappe/issues/3475).