### PR TITLE
Update the readme to add new Gantt logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,19 @@
-# Frappé Gantt
-A simple, interactive, modern gantt chart library for the web
+<div align="center">
+    <img src="https://github.com/frappe/design/blob/master/logos/gantt-logo.svg" height="128">
+    <h2>Frappe Gantt</h2>
+    <p align="center">
+        <p>A simple, interactive, modern gantt chart library for the web</p>
+        <a href="https://frappe.github.io/gantt">
+            <b>View the demo »</b>
+        </a>
+    </p>
+</div>
 
-![image](https://cloud.githubusercontent.com/assets/9355208/21537921/4a38b194-cdbd-11e6-8110-e0da19678a6d.png)
-
-#### View the demo [here](https://frappe.github.io/gantt).
+<p align="center">
+    <a href="https://frappe.github.io/gantt">
+        <img src="https://cloud.githubusercontent.com/assets/9355208/21537921/4a38b194-cdbd-11e6-8110-e0da19678a6d.png">
+    </a>
+</p>
 
 ### Install
 ```

--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ If you want to contribute:
 
 1. Clone this repo.
 2. `cd` into project directory
-3. `npm install`
-4. `npm run dev`
+3. `yarn`
+4. `yarn run dev`
 
 License: MIT
 


### PR DESCRIPTION
This PR adds the new Gantt logo to the README

![screenshot_20180130_175146](https://user-images.githubusercontent.com/9101092/35566121-3e08ada4-05e6-11e8-9ca5-7ac21ed4ed10.png)
