### PR TITLE
bind gantt events inside render

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -223,6 +223,7 @@ export default class Gantt {
         this.map_arrows_on_bars();
         this.set_width();
         this.set_scroll_position();
+        this.bind_events();
     }
 
     setup_layers() {


### PR DESCRIPTION
this PR contains a fix for #61 
change_view_mode is calling **render** internally, the problem is that events where not bound after each render, they was bound just in the constructor.
And that's whay after changing the view mode we loose events attachment to the dom.