### PR TITLE
fixed: Recursion when the tasks dependencies are wrong

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -799,8 +799,18 @@ export default class Gantt {
     get_all_dependent_tasks(task_id) {
         let out = [];
         let to_process = [task_id];
+
+        //counter for endless loop check
+        let counter = 0;
         while (to_process.length) {
+        	
             const deps = to_process.reduce((acc, curr) => {
+            	// break if the loop is endless
+                counter++;
+            	if(counter === 1000) {
+            		throw "Endless loop is occured, please check your task dependencies for recursion";
+            	}
+
                 acc = acc.concat(this.dependency_map[curr]);
                 return acc;
             }, []);


### PR DESCRIPTION
I had a problem when I added on my bad wrong dependencies of the tasks. I started research in the library and I found that the dependencies are point themselves. For that reason, I put a counter to prevent the endless loop in the library.