### PR TITLE
Fixed NodeList to Array<Node> bug

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -846,7 +846,8 @@ export default class Gantt {
     }
 
     unselect_all() {
-        [...this.$svg.querySelectorAll('.bar-wrapper')].forEach(el => {
+        Array.prototype.slice.call(this.$svg.querySelectorAll('.bar-wrapper'))
+            .forEach(el => {
             el.classList.remove('active');
         });
     }


### PR DESCRIPTION
[...this.$svg.querySelectorAll('.bar-wrapper')]
transpiles to 
`this.$svg.querySelectorAll('.bar-wrapper').slice()`
instead of
`Array.prototype.slice.call(this.$svg.querySelectorAll('.bar-wrapper'))`
