### PR TITLE
Make labels permanently visible

### DIFF
--- a/dist/frappe-gantt.css
+++ b/dist/frappe-gantt.css
@@ -1,6 +1,10 @@
 .gantt .grid-background {
   fill: none; }
 
+.gantt-target {
+  width: 100%;
+}
+
 .gantt .grid-header {
   fill: #ffffff;
   stroke: #e0e0e0;
@@ -51,7 +55,7 @@
 .gantt .bar-label {
   fill: #fff;
   dominant-baseline: central;
-  text-anchor: middle;
+  text-anchor: start;
   font-size: 12px;
   font-weight: lighter; }
   .gantt .bar-label.big {

--- a/dist/frappe-gantt.css
+++ b/dist/frappe-gantt.css
@@ -1,10 +1,6 @@
 .gantt .grid-background {
   fill: none; }
 
-.gantt-target {
-  width: 100%;
-}
-
 .gantt .grid-header {
   fill: #ffffff;
   stroke: #e0e0e0;

--- a/dist/frappe-gantt.js
+++ b/dist/frappe-gantt.js
@@ -765,7 +765,16 @@ class Bar {
             label.setAttribute('x', bar.getX() + bar.getWidth() + 5);
         } else {
             label.classList.remove('big');
-            label.setAttribute('x', bar.getX() + bar.getWidth() / 2);
+            label.setAttribute('x', bar.getX() + bar.getWidth() / 2 + label.getBBox().width/2);
+        }
+        /* Check if labels off screen on load and make them follow container if they are */
+        label.setAttribute('initialPos', label.getBBox().x);
+        if (div.scrollLeft > label.getAttribute('initialPos')) {
+            label.setAttribute('x', div.scrollLeft+5);
+        } else if (div.scrollLeft + div.clientWidth - label.getBBox().width < label.getAttribute('initialPos')) {
+            label.setAttribute('x', div.scrollLeft + div.clientWidth - label.getBBox().width-5);
+        } else {
+            label.setAttribute('x', label.getAttribute('initialPos'));
         }
     }
 

--- a/dist/frappe-gantt.js
+++ b/dist/frappe-gantt.js
@@ -768,13 +768,13 @@ class Bar {
             label.setAttribute('x', bar.getX() + bar.getWidth() / 2 + label.getBBox().width/2);
         }
         /* Check if labels off screen on load and make them follow container if they are */
-        label.setAttribute('initialPos', label.getBBox().x);
-        if (div.scrollLeft > label.getAttribute('initialPos')) {
+        label.setAttribute('data-initial-pos', label.getBBox().x);
+        if (div.scrollLeft > label.getAttribute('data-initial-pos')) {
             label.setAttribute('x', div.scrollLeft+5);
-        } else if (div.scrollLeft + div.clientWidth - label.getBBox().width < label.getAttribute('initialPos')) {
+        } else if (div.scrollLeft + div.clientWidth - label.getBBox().width < label.getAttribute('data-initial-pos')) {
             label.setAttribute('x', div.scrollLeft + div.clientWidth - label.getBBox().width-5);
         } else {
-            label.setAttribute('x', label.getAttribute('initialPos'));
+            label.setAttribute('x', label.getAttribute('data-initial-pos'));
         }
     }
 

--- a/index.html
+++ b/index.html
@@ -104,24 +104,24 @@
 		/* Function for labels to follow container */
 		const div = document.getElementsByClassName('gantt-container')[0];
 		div.onscroll = function() {
-			Array.from(document.getElementsByClassName('bar-label')).forEach(function(label_item) {
+			Array.from(document.getElementsByClassName('bar-label')).forEach(function(labelItem) {
 
-				var barWidth = label_item.previousSibling.previousSibling.getWidth();
-				var barX = label_item.previousSibling.previousSibling.getX();
+				var barWidth = labelItem.previousSibling.previousSibling.getWidth();
+				var barX = labelItem.previousSibling.previousSibling.getX();
 
-				if (div.scrollLeft > label_item.getAttribute('initialPos')) { // If user scrolls LEFT past label position
-					label_item.setAttribute('x', div.scrollLeft+5);
-				} else if (div.scrollLeft + div.clientWidth - label_item.getBBox().width < label_item.getAttribute('initialPos')) { // If user scrolls RIGHT past label position
-					label_item.setAttribute('x', div.scrollLeft + div.clientWidth - label_item.getBBox().width -5 );
+				if (div.scrollLeft > labelItem.getAttribute('data-initial-pos')) { // If user scrolls LEFT past label position
+					labelItem.setAttribute('x', div.scrollLeft+5);
+				} else if (div.scrollLeft + div.clientWidth - labelItem.getBBox().width < labelItem.getAttribute('data-initial-pos')) { // If user scrolls RIGHT past label position
+					labelItem.setAttribute('x', div.scrollLeft + div.clientWidth - labelItem.getBBox().width -5 );
 				} else {
-					label_item.setAttribute('x', label_item.getAttribute('initialPos'));
+					labelItem.setAttribute('x', labelItem.getAttribute('data-initial-pos'));
 				}
 
-				if (barWidth > label_item.getBBox().width) {
-					if (label_item.getBBox().x < barX || label_item.getBBox().x + label_item.getBBox().width > barX + barWidth) { // If label is outside bounds of bar
-						label_item.classList.add('big');
+				if (barWidth > labelItem.getBBox().width) {
+					if (labelItem.getBBox().x < barX || labelItem.getBBox().x + labelItem.getBBox().width > barX + barWidth) { // If label is outside bounds of bar
+						labelItem.classList.add('big');
 					} else {
-						label_item.classList.remove('big');
+						labelItem.classList.remove('big');
 					}
 				}
 			});

--- a/index.html
+++ b/index.html
@@ -100,6 +100,32 @@
 			language: 'en'
 		});
 		console.log(gantt_chart);
+
+		/* Function for labels to follow container */
+		const div = document.getElementsByClassName('gantt-container')[0];
+		div.onscroll = function() {
+			Array.from(document.getElementsByClassName('bar-label')).forEach(function(label_item) {
+
+				var barWidth = label_item.previousSibling.previousSibling.getWidth();
+				var barX = label_item.previousSibling.previousSibling.getX();
+
+				if (div.scrollLeft > label_item.getAttribute('initialPos')) { // If user scrolls LEFT past label position
+					label_item.setAttribute('x', div.scrollLeft+5);
+				} else if (div.scrollLeft + div.clientWidth - label_item.getBBox().width < label_item.getAttribute('initialPos')) { // If user scrolls RIGHT past label position
+					label_item.setAttribute('x', div.scrollLeft + div.clientWidth - label_item.getBBox().width -5 );
+				} else {
+					label_item.setAttribute('x', label_item.getAttribute('initialPos'));
+				}
+
+				if (barWidth > label_item.getBBox().width) {
+					if (label_item.getBBox().x < barX || label_item.getBBox().x + label_item.getBBox().width > barX + barWidth) { // If label is outside bounds of bar
+						label_item.classList.add('big');
+					} else {
+						label_item.classList.remove('big');
+					}
+				}
+			});
+		}
 	</script>
 </body>
 </html>


### PR DESCRIPTION
Hi guys,
We have been looking at porting this project into [dotProject](https://github.com/dotproject/dotProject) and found that with long running projects that have run for multiple years we were not able to see the labels along the whole gantt chart, so a solution we thought of to fix our problem and help make the project more generally user friendly was to make the labels follow the container as they were scrolled past so each step of the project is always visible along the chart.  
Hope this helps

![demo](https://user-images.githubusercontent.com/21019692/59737401-de174380-92a0-11e9-82e7-2e45e15a8af4.gif)  

