### PR TITLE
gat_bar > search with parseInt the id

### DIFF
--- a/dist/frappe-gantt.js
+++ b/dist/frappe-gantt.js
@@ -1896,7 +1896,7 @@ class Gantt {
 
     get_bar(id) {
         return this.bars.find(bar => {
-            return bar.task.id === id;
+            return bar.task.id === paseInt(id);
         });
     }
 


### PR DESCRIPTION
In some case, I have an error when I want to change the progress : the id is a string, and the comparaison doesn't work.