### PR TITLE
fix: hide popup while resizing or dragging events

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -699,7 +699,7 @@ export default class Gantt {
             bars.forEach(bar => {
                 const $bar = bar.$bar;
                 $bar.finaldx = this.get_snap_position(dx);
-
+                this.hide_popup();
                 if (is_resizing_left) {
                     if (parent_bar_id === bar.task.id) {
                         bar.update_bar_position({

--- a/src/popup.js
+++ b/src/popup.js
@@ -64,5 +64,6 @@ export default class Popup {
 
     hide() {
         this.parent.style.opacity = 0;
+        this.parent.style.left = 0;
     }
 }


### PR DESCRIPTION
**Issue:**
When Popup is opened, now if you drag the event or resize the event you cannot drag or resize until your cursor crosses the opened popup check the video below.

It also happens when the popup is hidden, it is happening because the position of the popup is still there it is just not visible.

**While Popup is open**
**Before:**

https://user-images.githubusercontent.com/30859809/148025950-433ac9a9-8267-4d2c-a10a-e9b0f6cf46dc.mov

**After:**

https://user-images.githubusercontent.com/30859809/148025981-e6655926-d52d-45da-a689-f92d947784fa.mov


**While Popup is hidden**
**Before:**

https://user-images.githubusercontent.com/30859809/148027976-e140fb9a-4ce9-41c5-bcfd-c3c718a626b9.mov

**After:**

https://user-images.githubusercontent.com/30859809/148028114-dda97c66-5b71-4de2-8b76-fb7fe1fcfd4d.mov
