### PR TITLE
Fix drag wiggles and jumping

### DIFF
--- a/dist/frappe-gantt.css
+++ b/dist/frappe-gantt.css
@@ -53,7 +53,8 @@
   dominant-baseline: central;
   text-anchor: middle;
   font-size: 12px;
-  font-weight: lighter; }
+  font-weight: lighter;
+  pointer-events: none; }
   .gantt .bar-label.big {
     fill: #555;
     text-anchor: start; }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "eslint-plugin-prettier": "^2.6.0",
     "jest": "^22.2.1",
     "prettier": "1.10.2",
-    "rollup": "^0.55.3",
+    "rollup": "^1.2.9",
     "rollup-plugin-sass": "^1.2.2",
     "rollup-plugin-uglify": "^3.0.0"
   },

--- a/src/gantt.scss
+++ b/src/gantt.scss
@@ -72,6 +72,7 @@ $handle-color: #ddd !default;
 		text-anchor: middle;
 		font-size: 12px;
 		font-weight: lighter;
+		pointer-events: none;
 
 		&.big {
 			fill: $text-light;

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,6 +10,16 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
+"@types/estree@*":
+  version "0.0.51"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.51.tgz#cfd70924a25a3fd32b218e5e420e6897e1ac4f40"
+  integrity sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==
+
+"@types/node@*":
+  version "17.0.21"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.21.tgz#864b987c0c68d07b4345845c3e63b75edd143644"
+  integrity sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ==
+
 abab@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"
@@ -37,6 +47,11 @@ acorn@^3.0.4:
 acorn@^5.0.0, acorn@^5.3.0, acorn@^5.4.0:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.4.1.tgz#fdc58d9d17f4a4e98d102ded826a9b9759125102"
+
+acorn@^7.1.0:
+  version "7.4.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
+  integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
 ajv-keywords@^2.1.0:
   version "2.1.1"
@@ -3553,9 +3568,14 @@ rollup-plugin-uglify@^3.0.0:
     estree-walker "^0.3.0"
     micromatch "^2.3.11"
 
-rollup@^0.55.3:
-  version "0.55.3"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.55.3.tgz#0af082a766d51c3058430c8372442ff5207d8736"
+rollup@^1.2.9:
+  version "1.32.1"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-1.32.1.tgz#4480e52d9d9e2ae4b46ba0d9ddeaf3163940f9c4"
+  integrity sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==
+  dependencies:
+    "@types/estree" "*"
+    "@types/node" "*"
+    acorn "^7.1.0"
 
 run-async@^2.2.0:
   version "2.3.0"


### PR DESCRIPTION
Fixes part of #92 

Previously: On Safari, if dragging via bar text, the bar would wiggle or even jump really far out of position.

Fix: Disable pointer events on bar label text. 

Additional fix: Upgrade rollup to a version that correctly rollsup the css.