### PR TITLE
fix: exception when moving invalid bar

### DIFF
--- a/src/bar.js
+++ b/src/bar.js
@@ -368,6 +368,7 @@ export default class Bar {
     }
 
     update_progressbar_position() {
+        if (this.invalid) return;
         this.$bar_progress.setAttribute('x', this.$bar.getX());
         this.$bar_progress.setAttribute(
             'width',
@@ -389,6 +390,7 @@ export default class Bar {
     }
 
     update_handle_position() {
+        if (this.invalid) return;
         const bar = this.$bar;
         this.handle_group
             .querySelector('.handle.left')


### PR DESCRIPTION
fix the exception when moving an invalid bar.

![image](https://user-images.githubusercontent.com/653441/175536050-1f37061f-d8c1-4e3a-8895-cd965ebcbb81.png)
