### PR TITLE
fix: child can go before parent when has multiple parents

### DIFF
--- a/src/bar.js
+++ b/src/bar.js
@@ -404,9 +404,9 @@ export default class Bar {
             const xs = this.task.dependencies.map((dep) => {
                 return this.gantt.get_bar(dep).$bar.getX();
             });
-            const valid_x = xs.reduce((_, curr) => {
-                return x >= curr;
-            }, x);
+            const valid_x = xs.reduce((prev, curr) => {
+                return prev && x >= curr;
+            }, true);
             if (!valid_x) return;
             this.update_attr(bar, 'x', x);
             this.x = x;


### PR DESCRIPTION
bugfix.
<img width="705" alt="企业微信截图_b2d4cd81-ac6a-4f45-a982-cf54dcb950dc" src="https://user-images.githubusercontent.com/653441/175915801-7acf3a9e-56c3-42f7-9099-2be1684e09ae.png">
