### PR TITLE
fix endless loop when moving a bar within a cyclic dependencies

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -813,11 +813,11 @@ export default class Gantt {
                 return acc;
             }, []);
 
-            out = out.concat(deps);
-            to_process = deps.filter((d) => !to_process.includes(d));
+            to_process = deps.filter((d) => !out.includes(d));
+            out = out.concat(to_process);
         }
 
-        return out.filter(Boolean);
+        return out.filter((id) => id && id !== task_id);
     }
 
     get_snap_position(dx) {


### PR DESCRIPTION
This commit fix the bug which causes an endless loop when moving a bar within a cyclic dependencies like the pic below.
<img width="356" alt="image" src="https://user-images.githubusercontent.com/653441/175944409-64974fab-adf7-4ce7-bb7b-713418b138f7.png">
