### PR TITLE
fix: bar width adjustment

### DIFF
--- a/src/bar.js
+++ b/src/bar.js
@@ -23,6 +23,7 @@ export default class Bar {
     prepare_values() {
         this.invalid = this.task.invalid;
         this.height = this.gantt.options.bar_height;
+        this.handle_width = 8;
         this.x = this.compute_x();
         this.y = this.compute_y();
         this.corner_radius = this.gantt.options.bar_corner_radius;
@@ -124,10 +125,10 @@ export default class Bar {
         if (this.invalid) return;
 
         const bar = this.$bar;
-        const handle_width = 8;
+        const handle_width = this.handle_width;
 
         createSVG('rect', {
-            x: bar.getX() + bar.getWidth() - 9,
+            x: bar.getX() + bar.getWidth() - handle_width - 1,
             y: bar.getY() + 1,
             width: handle_width,
             height: this.height - 2,
@@ -236,7 +237,7 @@ export default class Bar {
             }
             this.update_attr(bar, 'x', x);
         }
-        if (width && width >= this.gantt.options.column_width) {
+        if (width && width >= this.handle_width * 2 + 3) {
             this.update_attr(bar, 'width', width);
         }
         this.update_label_position();
@@ -395,7 +396,7 @@ export default class Bar {
             .setAttribute('x', bar.getX() + 1);
         this.handle_group
             .querySelector('.handle.right')
-            .setAttribute('x', bar.getEndX() - 9);
+            .setAttribute('x', bar.getEndX() - this.handle_width - 1);
         const handle = this.group.querySelector('.handle.progress');
         handle &&
             handle.setAttribute('points', this.get_progress_polygon_points());


### PR DESCRIPTION
**Before** this commit, when changing the size of a bar, the min-width is the same as column-width. 
![rec-tab (2)](https://user-images.githubusercontent.com/653441/175957089-75f7fa5b-4bf1-42d0-b07e-3ab030b71d42.gif)

**After** this commit, the min-width is set to handle-width * 2 + 3.
![rec-tab (1)](https://user-images.githubusercontent.com/653441/175957229-78722ce3-67c8-42b2-9f28-45fe3d101db1.gif)

