### PR TITLE
fix: wrong thick stick in view mode 'Month'

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -391,10 +391,7 @@ export default class Gantt {
                 tick_class += ' thick';
             }
             // thick ticks for quarters
-            if (
-                this.view_is(VIEW_MODE.MONTH) &&
-                (date.getMonth() + 1) % 3 === 0
-            ) {
+            if (this.view_is(VIEW_MODE.MONTH) && date.getMonth() % 3 === 0) {
                 tick_class += ' thick';
             }
 


### PR DESCRIPTION
Before, thick sticks are at the beggining of Mar, Jun, Sep & Dec.
<img width="679" alt="image" src="https://user-images.githubusercontent.com/653441/176361188-f8baa014-eb2d-4a37-8147-ac17f509c440.png">

After this change, thick sticks are at Jan, Apr, Jul & Oct.
<img width="823" alt="image" src="https://user-images.githubusercontent.com/653441/176361285-718188aa-45bb-4f72-9009-d9e5b3ca355c.png">
