### PR TITLE
Fixed event trigger twice when dragging then changing progress

### DIFF
--- a/dist/frappe-gantt.js
+++ b/dist/frappe-gantt.js
@@ -730,6 +730,7 @@ var Gantt = (function () {
 
         progress_changed() {
             const new_progress = this.compute_progress();
+            if (this.task.progress === new_progress) return;
             this.task.progress = new_progress;
             this.gantt.trigger_event('progress_change', [this.task, new_progress]);
         }
@@ -1827,6 +1828,7 @@ var Gantt = (function () {
             $.on(this.$svg, 'mouseup', () => {
                 is_resizing = false;
                 if (!($bar_progress && $bar_progress.finaldx)) return;
+
                 bar.progress_changed();
                 bar.set_action_completed();
             });


### PR DESCRIPTION
You can simulate this error by changing the progress bar of an event and then attempting to drag it(change start and end date). It will trigger the on_progress_change event needlessly. Furthermore, clicking anywhere else on the svg triggers a random on_progress_change event(after changing the progress), which this takes care of too.