### PR TITLE
Fixed Triggering of Extra Progress Change Events

### DIFF
--- a/dist/frappe-gantt.js
+++ b/dist/frappe-gantt.js
@@ -1828,7 +1828,6 @@ var Gantt = (function () {
             $.on(this.$svg, 'mouseup', () => {
                 is_resizing = false;
                 if (!($bar_progress && $bar_progress.finaldx)) return;
-
                 bar.progress_changed();
                 bar.set_action_completed();
             });

--- a/dist/frappe-gantt.js
+++ b/dist/frappe-gantt.js
@@ -730,6 +730,7 @@ var Gantt = (function () {
 
         progress_changed() {
             const new_progress = this.compute_progress();
+            if (this.task.progress === new_progress) return;
             this.task.progress = new_progress;
             this.gantt.trigger_event('progress_change', [this.task, new_progress]);
         }
@@ -1827,6 +1828,7 @@ var Gantt = (function () {
             $.on(this.$svg, 'mouseup', () => {
                 is_resizing = false;
                 if (!($bar_progress && $bar_progress.finaldx)) return;
+
                 bar.progress_changed();
                 bar.set_action_completed();
             });

--- a/src/bar.js
+++ b/src/bar.js
@@ -270,6 +270,7 @@ export default class Bar {
 
     progress_changed() {
         const new_progress = this.compute_progress();
+        if (this.task.progress === new_progress) return;
         this.task.progress = new_progress;
         this.gantt.trigger_event('progress_change', [this.task, new_progress]);
     }

--- a/src/bar.js
+++ b/src/bar.js
@@ -270,7 +270,6 @@ export default class Bar {
 
     progress_changed() {
         const new_progress = this.compute_progress();
-        if (this.task.progress === new_progress) return;
         this.task.progress = new_progress;
         this.gantt.trigger_event('progress_change', [this.task, new_progress]);
     }

--- a/src/index.js
+++ b/src/index.js
@@ -801,6 +801,7 @@ export default class Gantt {
             if (!($bar_progress && $bar_progress.finaldx)) return;
             bar.progress_changed();
             bar.set_action_completed();
+            $bar_progress.finaldx = 0;
         });
     }
 


### PR DESCRIPTION
When you change the progress of the bar, triggering the on_progress_change function, for any other click that you perform on the svg, it triggers this event. For example, changing the gantt bar positions(start and end date) or anywhere really. This can be especially seen when you change the progress of a bar and then go to change the date of that same bar. You will then see that the on_progress_change function and on_date_change function are both invoked! Hope this can get fixed as it is just a one line change.