### PR TITLE
fix: pop up not shown when progress bar is resized and README file update

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ If you want to contribute enhancements or fixes:
 
 1. Clone this repo.
 2. `cd` into project directory
-3. `yarn`
+3. Install Yarn by typing `npm install --global yarn` in your terminal
 4. `yarn run dev`
 5. Open `index.html` in your browser, make your code changes and test them.
 

--- a/dist/frappe-gantt.js
+++ b/dist/frappe-gantt.js
@@ -563,7 +563,7 @@ var Gantt = (function () {
         }
 
         show_popup() {
-            if (this.gantt.bar_being_dragged) return;
+            if (this.gantt.bar_being_ == null) return;
 
             const start_date = date_utils.format(
                 this.task._start,
@@ -642,7 +642,7 @@ var Gantt = (function () {
 
         set_action_completed() {
             this.action_completed = true;
-            setTimeout(() => (this.action_completed = false), 1000);
+            setTimeout(() => (this.action_completed = false), 200);
         }
 
         compute_start_end_date() {

--- a/src/bar.js
+++ b/src/bar.js
@@ -197,7 +197,7 @@ export default class Bar {
     }
 
     show_popup() {
-        if (this.gantt.bar_being_dragged) return;
+        if (this.gantt.bar_being_dragged == null) return;
 
         const start_date = date_utils.format(
             this.task._start,
@@ -276,7 +276,7 @@ export default class Bar {
 
     set_action_completed() {
         this.action_completed = true;
-        setTimeout(() => (this.action_completed = false), 1000);
+        setTimeout(() => (this.action_completed = false), 200);
     }
 
     compute_start_end_date() {


### PR DESCRIPTION
When this.gantt.bar_being_dragged is compared to null, there are no problems with showing the pop-up after resizing the progress bar.

Before changes:
if (this.gantt.bar_being_dragged) return;

![Before Changes](https://github.com/frappe/gantt/assets/88173271/28abbe4e-1846-42f7-9900-9f57bf6c738f)

After changes:
if (this.gantt.bar_being_dragged == null) return;

![After Changes](https://github.com/frappe/gantt/assets/88173271/eb7e7f6e-2cec-4610-ab27-de7f04b1a9ed)

Additionally, in set_action_completed(), it seems that the delay in setTimeout() is too big. By reducing it, the user can see the pop-up on the screen after resizing bars with no bugs.
Values changed -> From 1000 to 200

These adjustments should solve issue https://github.com/frappe/gantt/issues/319


README.md file update:
Enhancement of instructions in third step of Contributing Section.


Please let me know if everything works fine. Feedback is much appreciated. Thank you!