### PR TITLE
Feat: Add Grid highlight for current week, month, year

### DIFF
--- a/src/gantt.scss
+++ b/src/gantt.scss
@@ -40,6 +40,21 @@ $handle-color: #ddd !default;
 		opacity: 0.5;
 	}
 
+	.week-highlight {
+		fill: $light-yellow;
+		opacity: 0.5;
+	}
+
+	.month-highlight {
+		fill: $light-yellow;
+		opacity: 0.5;
+	}
+
+	.year-highlight {
+		fill: $light-yellow;
+		opacity: 0.5;
+	}
+
 	.arrow {
 		fill: none;
 		stroke: $text-muted;

--- a/src/index.js
+++ b/src/index.js
@@ -412,13 +412,46 @@ export default class Gantt {
         }
     }
 
-    make_grid_highlights() {
-        // highlight today's date
+    computeGridHighlightDimensions(view_mode) {
+        let xDist = 0;
+
         if (this.view_is(VIEW_MODE.DAY)) {
-            const x =
-                (date_utils.diff(date_utils.today(), this.gantt_start, 'hour') /
-                    this.options.step) *
+            return (date_utils.diff(date_utils.today(), this.gantt_start, 'hour') /
+                this.options.step) *
                 this.options.column_width;
+        }
+
+        for (let date of this.dates) {
+            const todayDate = new Date();
+            const startDate = new Date(date);
+            let endDate = new Date(date);
+            switch (view_mode) {
+                case VIEW_MODE.WEEK:
+                    endDate.setDate(date.getDate() + 7);
+                    break;
+                case VIEW_MODE.MONTH:
+                    endDate.setMonth(date.getMonth() + 1);
+                    break;
+                case VIEW_MODE.YEAR:
+                    endDate.setFullYear(date.getFullYear() + 1);
+                    break;
+            }
+
+            if (todayDate >= startDate && todayDate <= endDate) {
+                break;
+            } else {
+                xDist += this.options.column_width;
+            }
+        }
+        return xDist;
+    }
+
+    make_grid_highlights() {
+        // highlight today's | week's date
+        if (this.view_is(VIEW_MODE.DAY) || this.view_is(VIEW_MODE.WEEK) || this.view_is(VIEW_MODE.MONTH) || this.view_is(VIEW_MODE.YEAR)) {
+
+            let x = this.computeGridHighlightDimensions(this.options.view_mode);
+
             const y = 0;
 
             const width = this.options.column_width;
@@ -428,12 +461,27 @@ export default class Gantt {
                 this.options.header_height +
                 this.options.padding / 2;
 
+            let className = '';
+            switch (this.options.view_mode) {
+                case VIEW_MODE.DAY:
+                    className = 'today-highlight'
+                    break;
+                case VIEW_MODE.WEEK:
+                    className = 'week-highlight'
+                    break;
+                case VIEW_MODE.MONTH:
+                    className = 'month-highlight'
+                    break;
+                case VIEW_MODE.YEAR:
+                    className = 'year-highlight'
+                    break;
+            }
             createSVG('rect', {
                 x,
                 y,
                 width,
                 height,
-                class: 'today-highlight',
+                class: className,
                 append_to: this.layers.grid,
             });
         }

--- a/src/index.js
+++ b/src/index.js
@@ -412,6 +412,7 @@ export default class Gantt {
         }
     }
 
+    //compute the horizontal x distance
     computeGridHighlightDimensions(view_mode) {
         let xDist = 0;
 
@@ -424,7 +425,7 @@ export default class Gantt {
         for (let date of this.dates) {
             const todayDate = new Date();
             const startDate = new Date(date);
-            let endDate = new Date(date);
+            const endDate = new Date(date);
             switch (view_mode) {
                 case VIEW_MODE.WEEK:
                     endDate.setDate(date.getDate() + 7);
@@ -436,7 +437,6 @@ export default class Gantt {
                     endDate.setFullYear(date.getFullYear() + 1);
                     break;
             }
-
             if (todayDate >= startDate && todayDate <= endDate) {
                 break;
             } else {
@@ -447,13 +447,11 @@ export default class Gantt {
     }
 
     make_grid_highlights() {
-        // highlight today's | week's date
+        // highlight today's | week's | month's | year's
         if (this.view_is(VIEW_MODE.DAY) || this.view_is(VIEW_MODE.WEEK) || this.view_is(VIEW_MODE.MONTH) || this.view_is(VIEW_MODE.YEAR)) {
 
-            let x = this.computeGridHighlightDimensions(this.options.view_mode);
-
+            const x = this.computeGridHighlightDimensions(this.options.view_mode);
             const y = 0;
-
             const width = this.options.column_width;
             const height =
                 (this.options.bar_height + this.options.padding) *


### PR DESCRIPTION
### Grid Highlight for Current Week, Month and Year

Problem : 
- There is no Grid Highlight for current week, month and year.

Solution : 

- Iterate over the dates in current view mode, And check whether the today's date is in between range (section).
- Compute the Horizontal X Distance from start. And Break the loop if the today's date is in between.


![Screenshot 2024-03-26 at 4 29 58 PM](https://github.com/frappe/gantt/assets/55011825/cf86cc19-fcf2-493b-b160-e911c69e9dd8)
![Screenshot 2024-03-26 at 4 32 38 PM](https://github.com/frappe/gantt/assets/55011825/fbfb85c9-5dfb-4eb9-8fe8-0ccb8cb53e6b)
![Screenshot 2024-03-26 at 4 32 53 PM](https://github.com/frappe/gantt/assets/55011825/b22d0bda-72b2-40f8-8aca-5931a86fdb73)


