### PR TITLE
Minor Fixes

### DIFF
--- a/src/bar.js
+++ b/src/bar.js
@@ -262,7 +262,7 @@ export default class Bar {
             }
             this.update_attr(bar, 'x', x);
         }
-        if (width && width >= this.gantt.options.column_width) {
+        if (width) {
             this.update_attr(bar, 'width', width);
         }
         this.update_label_position();

--- a/src/bar.js
+++ b/src/bar.js
@@ -174,7 +174,7 @@ export default class Bar {
             append_to: this.handle_group,
         });
 
-        if (this.task.progress && this.task.progress < 100) {
+        if (this.task.progress < 100) {
             this.$handle_progress = createSVG('polygon', {
                 points: this.get_progress_polygon_points().join(','),
                 class: 'handle progress',

--- a/src/gantt.scss
+++ b/src/gantt.scss
@@ -14,6 +14,9 @@ $handle-color: #ddd !default;
 $light-blue: #c4c4e9 !default;
 
 .gantt {
+	user-select: none;
+	-webkit-user-select: none;
+		
 	.grid-background {
 		fill: none;
 	}
@@ -69,7 +72,6 @@ $light-blue: #c4c4e9 !default;
 		stroke: $bar-stroke;
 		stroke-width: 0;
 		transition: stroke-width .3s ease;
-		user-select: none;
 	}
 	.bar-progress {
 		fill: $blue;

--- a/src/index.js
+++ b/src/index.js
@@ -588,9 +588,9 @@ export default class Gantt {
         };
 
         const x_pos = {
-            'Quarter Day_lower': 0,
+            'Quarter Day_lower': this.options.column_width / 2,
             'Quarter Day_upper': this.options.column_width * 2,
-            'Half Day_lower': 0,
+            'Half Day_lower': this.options.column_width / 2,
             'Half Day_upper': this.options.column_width,
             Day_lower: this.options.column_width / 2,
             Day_upper: (this.options.column_width * 30) / 2,

--- a/src/index.js
+++ b/src/index.js
@@ -588,10 +588,10 @@ export default class Gantt {
         };
 
         const x_pos = {
-            'Quarter Day_lower': (this.options.column_width * 4) / 2,
-            'Quarter Day_upper': 0,
-            'Half Day_lower': (this.options.column_width * 2) / 2,
-            'Half Day_upper': 0,
+            'Quarter Day_lower': 0,
+            'Quarter Day_upper': this.options.column_width * 2,
+            'Half Day_lower': 0,
+            'Half Day_upper': this.options.column_width,
             Day_lower: this.options.column_width / 2,
             Day_upper: (this.options.column_width * 30) / 2,
             Week_lower: 0,

--- a/src/index.js
+++ b/src/index.js
@@ -526,7 +526,7 @@ export default class Gantt {
 
     get_date_info(date, last_date, i) {
         if (!last_date) {
-            last_date = date_utils.add(date, 1, 'year');
+            last_date = date_utils.add(date, 1, 'day');
         }
         const date_text = {
             'Quarter Day_lower': date_utils.format(


### PR DESCRIPTION
Closes #13, #22, and #299.

Also, ensures that `user-select: none` works on Safari and apples to _all_ text inside Gantt, not just the bars.

## Screenshots
### First Date Disappearing
Before:
<img width="428" alt="image" src="https://github.com/frappe/gantt/assets/62411302/9db47475-7219-421f-bb25-e7709bb00151">
After:
<img width="400" alt="image" src="https://github.com/frappe/gantt/assets/62411302/21b3c9ba-0c73-4cc9-a231-af8cd7c56220">

### Progress bar
This is kinda awkward - I think we anyway need to come up with a way to resize through text. Works for now, though.
<img width="134" alt="image" src="https://github.com/frappe/gantt/assets/62411302/3871f3f4-e0f0-4b99-890a-170df56c8e53">

### Inconsistent time display
This was a significant bug: tasks were shown with 12 hours difference from the original thing in Half/Quarter Day view. Fixed now.
<img width="310" alt="image" src="https://github.com/frappe/gantt/assets/62411302/937852d6-03b8-480b-af33-62475b9c3030">


The second PR ensures that the dates aren't cut off like this:
<img width="195" alt="image" src="https://github.com/frappe/gantt/assets/62411302/87b5bb0b-c9f1-4ce9-88f6-52e05d37352f">
It now looks like this:
<img width="233" alt="image" src="https://github.com/frappe/gantt/assets/62411302/33fa9629-49c0-4eeb-9b10-589cfb13b2a4">




