### PR TITLE
fix: Cannot read properties of undefined (reading '$bar')

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -779,7 +779,7 @@ export default class Gantt {
         parent_bar_id,
         ...this.get_all_dependent_tasks(parent_bar_id),
       ];
-      bars = ids.map((id) => this.get_bar(id));
+      bars = ids.map((id) => this.get_bar(id)).filter(bar => bar !== undefined);
 
       this.bar_being_dragged = parent_bar_id;
 
@@ -972,7 +972,7 @@ export default class Gantt {
 
   get_bar(id) {
     return this.bars.find((bar) => {
-      return bar.task.id === id;
+      return bar.task.id == id;
     });
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -966,7 +966,7 @@ export default class Gantt {
 
   get_task(id) {
     return this.tasks.find((task) => {
-      return task.id === id;
+      return task.id == id;
     });
   }
 


### PR DESCRIPTION
I think the problem is in the filter in the get_bars function

https://github.com/frappe/gantt/blob/ea6259adceff6e7032d0abd4dcf87ff278251bee/src/index.js#L973C3-L977C4
```
get_bar(id) {
    return this.bars.find((bar) => {
      return bar.task.id === id;
    });
 }
```

Type of id can be String and type of bar.task.id is Number. 
We can:
- Use comparison with '==' instead of strict '==='
- Use parseInt for id if id is numeric

Also i added filter to this line
https://github.com/frappe/gantt/blob/ea6259adceff6e7032d0abd4dcf87ff278251bee/src/index.js#L782

`bars = ids.map((id) => this.get_bar(id)).filter(bar => bar !== undefined);`

With this filter we will not get an error if result of get_bar(id) is undefined


Same with get_task(task_id) (dependency arrows doesn't show because result of get_task is undefined): Dependency also has a strict comparison and if id is a number then the passed task_id could be a string (I use a numeric id to work with events from the database) and task.id could be a number