### PR TITLE
Custom Index added for each tasks to support multiple tasks in same row

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -151,6 +151,11 @@ export default class Gantt {
       // cache index
       task._index = i;
 
+      // To support tasks for same row
+      if (typeof task.custom_index === 'number') {
+        task._index = task.custom_index;
+      }
+
       // invalid dates
       if (!task.start && !task.end) {
         const today = date_utils.today();


### PR DESCRIPTION
In order to allow multiple tasks to be allowed in a single row, `custom_index` can be added to the `task` object.