### PR TITLE
Do not access `this.popup` if it is undefined

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -886,7 +886,7 @@ export default class Gantt {
       }
 
       bar_wrapper.classList.add("active");
-      this.popup.parent.classList.add('hidden')
+      this.popup?.parent.classList.add('hidden')
 
       x_on_start = e.offsetX;
       y_on_start = e.offsetY;
@@ -1121,7 +1121,7 @@ export default class Gantt {
     [...this.$svg.querySelectorAll(".bar-wrapper")].forEach((el) => {
       el.classList.remove("active");
     });
-    this.popup.parent.classList.remove('hidden')
+    this.popup?.parent.classList.remove('hidden')
   }
 
   view_is(modes) {


### PR DESCRIPTION
This check is necessary when the `popup` option is set to `false` and there is never a popup created