### PR TITLE
Use CSS instead of JS to align lower text dates

### DIFF
--- a/src/gantt.scss
+++ b/src/gantt.scss
@@ -50,6 +50,7 @@ $dark-blue: #2c94ec !default;
     font-size: 14px;
     position: absolute;
     width: fit-content;
+    transform: translateX(-50%);
   }
 
   .upper-text {

--- a/src/index.js
+++ b/src/index.js
@@ -653,7 +653,7 @@ export default class Gantt {
         append_to: this.$lower_header
       })
       $lower_text.innerText = date.lower_text
-      $lower_text.style.left = +$lower_text.style.left.slice(0, -2) - $lower_text.clientWidth / 2 + 'px'
+      $lower_text.style.left = +$lower_text.style.left.slice(0, -2) + 'px'
 
       if (date.upper_text) {
         this.upper_texts_x[date.upper_text] = date.upper_x


### PR DESCRIPTION
This drastically improves performance of the `create_dates` method, which is important when rendering a many dates (i.e. for the `Hours` view).

The previous implementation calls `clientWidth` in a loop which was over 50% of the execution time on this method. See the flame graph below:

![image](https://github.com/user-attachments/assets/62b938e3-ab20-40d0-9d7c-a4641bf20a55)

In my tests, while rendering a chart with tasks spanning approximately 1 year, the execution time of `create_dates` decreased from 27,844ms to 6,342ms when switching to the hours view