### PR TITLE
View Modes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ node_modules
 .DS_Store
 
 gh-pages
+feedback.md

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ coverage
 
 # Compiled binary addons (http://nodejs.org/api/addons.html)
 build/Release
+dist/*
 
 # Dependency directory
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git

--- a/index.html
+++ b/index.html
@@ -68,8 +68,8 @@
                     dependencies: 'Task 2',
                 },
                 {
-                    start: '2024-04-08',
-                    end: '2024-04-10',
+                    start: '2024-03-08',
+                    end: '2024-05-10',
                     name: 'Deploy',
                     id: 'Task 4',
                     progress: 0,
@@ -108,7 +108,7 @@
                 // on_hover (task, x, y) {
                 //   console.log("Hover", x, y);
                 // }
-                view_mode: 'Day',
+                view_mode: 'Month',
                 // view_modes: [
                 //     {
                 //         name: 'Custom Day',

--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
             let tasks = [
                 {
                     start: '2024-04-01',
-                    end: '2024-04-01',
+                    end: '2024-04-04',
                     name: 'Redesign website',
                     id: 'Task 0',
                     progress: 30,
@@ -77,7 +77,7 @@
                 },
                 {
                     start: '2024-04-21',
-                    end: '2024-04-29',
+                    end: '2024-05-29',
                     name: 'Go Live!',
                     id: 'Task 5',
                     progress: 0,
@@ -85,22 +85,22 @@
                     custom_class: 'bar-milestone',
                 },
                 // {
-                // 	start: '2014-01-05',
-                // 	end: '2019-10-12',
-                // 	name: 'Long term task',
-                // 	id: "Task 6",
-                // 	progress: 0
-                // }
+                //     start: '2014-01-05',
+                //     end: '2019-10-12',
+                //     name: 'Long term task',
+                //     id: 'Task 6',
+                //     progress: 0,
+                // },
             ];
 
             // Uncomment to test fixed header
-            tasks = [
-                ...tasks,
-                ...Array.from({ length: tasks.length * 3 }, (_, i) => ({
-                    ...tasks[i % 3],
-                    id: i,
-                })),
-            ];
+            // tasks = [
+            //     ...tasks,
+            //     ...Array.from({ length: tasks.length * 3 }, (_, i) => ({
+            //         ...tasks[i % 3],
+            //         id: i,
+            //     })),
+            // ];
             let gantt_chart = new Gantt('.gantt-target', tasks, {
                 on_click(task) {
                     console.log('Click', task);
@@ -109,15 +109,13 @@
                 //   console.log("Hover", x, y);
                 // }
                 view_mode: 'Day',
-                view_mode_padding: { DAY: '3d' },
-                custom_view_modes: [
-                    {
-                        name: 'Custom Day',
-                        padding: '1m',
-                        step: 3,
-                        unit: 'day',
-                    },
-                ],
+                // view_modes: [
+                //     {
+                //         name: 'Custom Day',
+                //         padding: '1m',
+                //         step: '1d',
+                //     },
+                // ],
                 // popup_on: 'click',
                 // move_dependencies: false,
                 // scroll_to: 'today',

--- a/src/bar.js
+++ b/src/bar.js
@@ -520,7 +520,11 @@ export default class Bar {
                 date_utils.diff(task_start, gantt_start, 'month') * 30;
             const dayInMonth = Math.min(
                 29,
-                date_utils.format(task_start, 'DD'),
+                date_utils.format(
+                    task_start,
+                    'DD',
+                    this.gantt.options.language,
+                ),
             );
             const diff = diffDaysBasedOn30DayMonths + dayInMonth;
 

--- a/src/bar.js
+++ b/src/bar.js
@@ -505,11 +505,9 @@ export default class Bar {
         const task_start = this.task._start;
         const gantt_start = this.gantt.gantt_start;
 
-        const diff = date_utils.diff(
-            task_start,
-            gantt_start,
-            this.gantt.config.unit,
-        );
+        const diff =
+            date_utils.diff(task_start, gantt_start, this.gantt.config.unit) /
+            this.gantt.config.step;
         let x = diff * column_width;
 
         /* Since the column width is based on 30,
@@ -540,6 +538,13 @@ export default class Bar {
     }
 
     compute_duration() {
+        console.log(
+            date_utils.diff(
+                this.task._end,
+                this.task._start,
+                this.gantt.config.unit,
+            ),
+        );
         this.duration =
             date_utils.diff(
                 this.task._end,

--- a/src/bar.js
+++ b/src/bar.js
@@ -538,13 +538,6 @@ export default class Bar {
     }
 
     compute_duration() {
-        console.log(
-            date_utils.diff(
-                this.task._end,
-                this.task._start,
-                this.gantt.config.unit,
-            ),
-        );
         this.duration =
             date_utils.diff(
                 this.task._end,
@@ -558,31 +551,31 @@ export default class Bar {
             rem,
             position;
 
-        if (this.gantt.view_is('Week')) {
-            rem = dx % (this.gantt.config.column_width / 7);
-            position =
-                odx -
-                rem +
-                (rem < this.gantt.config.column_width / 14
-                    ? 0
-                    : this.gantt.config.column_width / 7);
-        } else if (this.gantt.view_is('Month')) {
-            rem = dx % (this.gantt.config.column_width / 30);
-            position =
-                odx -
-                rem +
-                (rem < this.gantt.config.column_width / 60
-                    ? 0
-                    : this.gantt.config.column_width / 30);
-        } else {
-            rem = dx % this.gantt.config.column_width;
-            position =
-                odx -
-                rem +
-                (rem < this.gantt.config.column_width / 2
-                    ? 0
-                    : this.gantt.config.column_width);
-        }
+        // if (this.gantt.view_is('Week')) {
+        //     rem = dx % (this.gantt.config.column_width / 7);
+        //     position =
+        //         odx -
+        //         rem +
+        //         (rem < this.gantt.config.column_width / 14
+        //             ? 0
+        //             : this.gantt.config.column_width / 7);
+        // } else if (this.gantt.view_is('Month')) {
+        //     rem = dx % (this.gantt.config.column_width / 30);
+        //     position =
+        //         odx -
+        //         rem +
+        //         (rem < this.gantt.config.column_width / 60
+        //             ? 0
+        //             : this.gantt.config.column_width / 30);
+        // } else {
+        rem = dx % this.gantt.config.column_width;
+        position =
+            odx -
+            rem +
+            (rem < this.gantt.config.column_width / 2
+                ? 0
+                : this.gantt.config.column_width);
+        // }
         return position;
     }
 

--- a/src/date_utils.js
+++ b/src/date_utils.js
@@ -6,7 +6,6 @@ const MINUTE = 'minute';
 const SECOND = 'second';
 const MILLISECOND = 'millisecond';
 
-
 export default {
     parse_duration(duration) {
         const regex = /([0-9]+)(y|m|d|h|min|s|ms)/gm;
@@ -84,7 +83,7 @@ export default {
             month: 'long',
         });
         const dateTimeFormatShort = new Intl.DateTimeFormat(lang, {
-            month: "short",
+            month: 'short',
         });
         const month_name = dateTimeFormat.format(date);
         const month_name_capitalized =

--- a/src/date_utils.js
+++ b/src/date_utils.js
@@ -251,6 +251,10 @@ export default {
         }
         return 28;
     },
+
+    get_days_in_year(date) {
+        return date.getFullYear() % 4 ? 365 : 366;
+    },
 };
 
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/padStart

--- a/src/date_utils.js
+++ b/src/date_utils.js
@@ -235,6 +235,21 @@ export default {
         ];
     },
 
+    convert_scales(period, to_scale) {
+        const TO_DAYS = {
+            millisecond: 1 / 60 / 60 / 24 / 1000,
+            second: 1 / 60 / 60 / 24,
+            minute: 1 / 60 / 24,
+            hour: 1 / 24,
+            day: 1,
+            month: 30,
+            year: 365,
+        };
+        const { duration, scale } = this.parse_duration(period);
+        let in_days = duration * TO_DAYS[scale];
+        return in_days / TO_DAYS[to_scale];
+    },
+
     get_days_in_month(date) {
         const no_of_days = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
 

--- a/src/date_utils.js
+++ b/src/date_utils.js
@@ -122,7 +122,7 @@ export default {
         return str;
     },
 
-    diff(date_a, date_b, scale = DAY) {
+    diff(date_a, date_b, scale = 'day') {
         let milliseconds, seconds, hours, minutes, days, months, years;
 
         milliseconds = date_a - date_b;
@@ -131,13 +131,14 @@ export default {
         hours = minutes / 60;
         days = hours / 24;
         // Calculate months across years
-        const yearDiff = date_a.getFullYear() - date_b.getFullYear();
-        const monthDiff = date_a.getMonth() - date_b.getMonth();
+        let yearDiff = date_a.getFullYear() - date_b.getFullYear();
+        let monthDiff = date_a.getMonth() - date_b.getMonth();
+        // calculate extra
+        monthDiff += (days % 30) / 30;
 
         /* If monthDiff is negative, date_b is in an earlier month than
         date_a and thus subtracted from the year difference in months */
         months = yearDiff * 12 + monthDiff;
-
         /* If date_a's (e.g. march 1st) day of the month is smaller than date_b (e.g. february 28th),
         adjust the month difference */
         if (date_a.getDate() < date_b.getDate()) {
@@ -151,16 +152,18 @@ export default {
             scale += 's';
         }
 
-        return Math.floor(
-            {
-                milliseconds,
-                seconds,
-                minutes,
-                hours,
-                days,
-                months,
-                years,
-            }[scale],
+        return (
+            Math.round(
+                {
+                    milliseconds,
+                    seconds,
+                    minutes,
+                    hours,
+                    days,
+                    months,
+                    years,
+                }[scale] * 100,
+            ) / 100
         );
     },
 

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -38,6 +38,7 @@ const DEFAULT_VIEW_MODES = [
     {
         name: 'Day',
         padding: '14d',
+        format_string: 'YYYY-MM-DD',
         step: '1d',
         lower_text: (d, ld, lang) =>
             d.getDate() !== ld.getDate() ? date_utils.format(d, 'D', lang) : '',
@@ -45,6 +46,7 @@ const DEFAULT_VIEW_MODES = [
             d.getMonth() !== ld.getMonth()
                 ? date_utils.format(d, 'MMMM', lang)
                 : '',
+        thick_line: (d) => d.getDay() === 1,
     },
     {
         name: 'Week',
@@ -59,6 +61,7 @@ const DEFAULT_VIEW_MODES = [
             d.getMonth() !== ld.getMonth()
                 ? date_utils.format(d, 'MMMM', lang)
                 : '',
+        thick_line: (d) => d.getDate() >= 1 && d.getDate() <= 7,
     },
     {
         name: 'Month',
@@ -71,6 +74,7 @@ const DEFAULT_VIEW_MODES = [
             d.getMonth() !== ld.getMonth()
                 ? date_utils.format(d, 'YYYY', lang)
                 : '',
+        thick_line: (d) => d.getMonth() % 3 === 0,
     },
     {
         name: 'Year',

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -10,6 +10,7 @@ const DEFAULT_VIEW_MODES = [
             d.getDate() !== ld.getDate()
                 ? date_utils.format(d, 'D MMMM', lang)
                 : '',
+        upper_text_frequency: 24,
     },
     {
         name: 'Quarter Day',
@@ -21,6 +22,7 @@ const DEFAULT_VIEW_MODES = [
             d.getDate() !== ld.getDate()
                 ? date_utils.format(d, 'D MMM', lang)
                 : '',
+        upper_text_frequency: 4,
     },
     {
         name: 'Half Day',
@@ -34,6 +36,7 @@ const DEFAULT_VIEW_MODES = [
                     ? date_utils.format(d, 'D MMM', lang)
                     : date_utils.format(d, 'D', lang)
                 : '',
+        upper_text_frequency: 2,
     },
     {
         name: 'Day',
@@ -62,6 +65,7 @@ const DEFAULT_VIEW_MODES = [
                 ? date_utils.format(d, 'MMMM', lang)
                 : '',
         thick_line: (d) => d.getDate() >= 1 && d.getDate() <= 7,
+        upper_text_frequency: 4,
     },
     {
         name: 'Month',
@@ -87,6 +91,7 @@ const DEFAULT_VIEW_MODES = [
             d.getMonth() !== ld.getMonth()
                 ? date_utils.format(d, 'YYYY', lang)
                 : '',
+        upper_text_frequency: 30,
     },
 ];
 

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -93,7 +93,7 @@ const DEFAULT_VIEW_MODES = [
                 ? date_utils.format(d, 'YYYY', lang)
                 : '',
         upper_text_frequency: 30,
-        default_snap: '1m',
+        default_snap: '30d',
     },
 ];
 

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -110,6 +110,7 @@ const DEFAULT_OPTIONS = {
     auto_move_label: true,
     today_button: true,
     view_mode_select: false,
+    snap_by_day: false,
 };
 
 export { DEFAULT_OPTIONS, DEFAULT_VIEW_MODES };

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -69,13 +69,13 @@ const DEFAULT_VIEW_MODES = [
     },
     {
         name: 'Month',
-        padding: '1m',
+        padding: '2m',
         step: '1m',
         column_width: 120,
         format_string: 'YYYY-MM',
         lower_text: 'MMMM',
         upper_text: (d, ld, lang) =>
-            d.getMonth() !== ld.getMonth()
+            !ld || d.getFullYear() !== ld.getFullYear()
                 ? date_utils.format(d, 'YYYY', lang)
                 : '',
         thick_line: (d) => d.getMonth() % 3 === 0,
@@ -83,16 +83,11 @@ const DEFAULT_VIEW_MODES = [
     },
     {
         name: 'Year',
-        padding: '1m',
+        padding: '2y',
         step: '1y',
         column_width: 120,
         format_string: 'YYYY',
-        lower_text: 'YYYY',
-        upper_text: (d, ld, lang) =>
-            d.getMonth() !== ld.getMonth()
-                ? date_utils.format(d, 'YYYY', lang)
-                : '',
-        upper_text_frequency: 30,
+        upper_text: 'YYYY',
         default_snap: '30d',
     },
 ];

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -1,0 +1,115 @@
+import date_utils from './date_utils';
+
+const DEFAULT_VIEW_MODES = [
+    {
+        name: 'Hour',
+        padding: '7d',
+        step: '1h',
+        lower_text: 'HH',
+        upper_text: (d, ld, lang) =>
+            d.getDate() !== ld.getDate()
+                ? date_utils.format(d, 'D MMMM', lang)
+                : '',
+    },
+    {
+        name: 'Quarter Day',
+        padding: '7d',
+        step: '6h',
+        format_string: 'YYYY-MM-DD HH',
+        lower_text: 'HH',
+        upper_text: (d, ld, lang) =>
+            d.getDate() !== ld.getDate()
+                ? date_utils.format(d, 'D MMM', lang)
+                : '',
+    },
+    {
+        name: 'Half Day',
+        padding: '7d',
+        step: '12h',
+        format_string: 'YYYY-MM-DD HH',
+        lower_text: 'HH',
+        upper_text: (d, ld, lang) =>
+            d.getDate() !== ld.getDate()
+                ? d.getMonth() !== d.getMonth()
+                    ? date_utils.format(d, 'D MMM', lang)
+                    : date_utils.format(d, 'D', lang)
+                : '',
+    },
+    {
+        name: 'Day',
+        padding: '14d',
+        step: '1d',
+        lower_text: (d, ld, lang) =>
+            d.getDate() !== ld.getDate() ? date_utils.format(d, 'D', lang) : '',
+        upper_text: (d, ld, lang) =>
+            d.getMonth() !== ld.getMonth()
+                ? date_utils.format(d, 'MMMM', lang)
+                : '',
+    },
+    {
+        name: 'Week',
+        padding: '1m',
+        step: '7d',
+        column_width: 140,
+        lower_text: (d, ld, lang) =>
+            d.getMonth() !== ld.getMonth()
+                ? date_utils.format(d, 'D MMM', lang)
+                : date_utils.format(d, 'D', lang),
+        upper_text: (d, ld, lang) =>
+            d.getMonth() !== ld.getMonth()
+                ? date_utils.format(d, 'MMMM', lang)
+                : '',
+    },
+    {
+        name: 'Month',
+        padding: '1m',
+        step: '1m',
+        column_width: 120,
+        format_string: 'YYYY-MM',
+        lower_text: 'MMMM',
+        upper_text: (d, ld, lang) =>
+            d.getMonth() !== ld.getMonth()
+                ? date_utils.format(d, 'YYYY', lang)
+                : '',
+    },
+    {
+        name: 'Year',
+        padding: '1m',
+        step: '1y',
+        column_width: 120,
+        format_string: 'YYYY',
+        lower_text: 'YYYY',
+        upper_text: (d, ld, lang) =>
+            d.getMonth() !== ld.getMonth()
+                ? date_utils.format(d, 'YYYY', lang)
+                : '',
+    },
+];
+
+const DEFAULT_OPTIONS = {
+    header_height: 65,
+    column_width: 30,
+    view_modes: DEFAULT_VIEW_MODES,
+    bar_height: 30,
+    bar_corner_radius: 3,
+    arrow_curve: 5,
+    padding: 18,
+    view_mode: 'Day',
+    date_format: 'YYYY-MM-DD',
+    move_dependencies: true,
+    show_expected_progress: false,
+    popup: null,
+    popup_on: 'hover',
+    language: 'en',
+    readonly: false,
+    progress_readonly: false,
+    dates_readonly: false,
+    highlight_weekend: true,
+    scroll_to: 'start',
+    lines: 'both',
+    auto_move_label: true,
+    today_button: true,
+    view_mode_select: false,
+};
+
+export { DEFAULT_OPTIONS, DEFAULT_VIEW_MODES };

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -79,6 +79,7 @@ const DEFAULT_VIEW_MODES = [
                 ? date_utils.format(d, 'YYYY', lang)
                 : '',
         thick_line: (d) => d.getMonth() % 3 === 0,
+        default_snap: '7d',
     },
     {
         name: 'Year',
@@ -92,6 +93,7 @@ const DEFAULT_VIEW_MODES = [
                 ? date_utils.format(d, 'YYYY', lang)
                 : '',
         upper_text_frequency: 30,
+        default_snap: '1m',
     },
 ];
 
@@ -119,7 +121,7 @@ const DEFAULT_OPTIONS = {
     auto_move_label: true,
     today_button: true,
     view_mode_select: false,
-    snap_by_day: false,
+    default_snap: '1d',
 };
 
 export { DEFAULT_OPTIONS, DEFAULT_VIEW_MODES };

--- a/src/gantt.css
+++ b/src/gantt.css
@@ -10,10 +10,10 @@
     --light-border-color: #ebeff2;
     --light-yellow: #f6e796;
     --holiday-color: #f9fafa;
-    --text-muted: #666;
+    --text-muted: #7c7c7c;
     --text-grey: #98a1a9;
     --text-light: #fff;
-    --text-dark: #111;
+    --text-dark: #171717;
     --progress: #ebeef0;
     --handle-color: #dcdce4;
     --handle-color-important: #94c4f4;
@@ -74,7 +74,6 @@
     & .lower-text,
     & .upper-text {
         text-anchor: middle;
-        color: var(--text-dark);
     }
 
     & .upper-header {
@@ -90,6 +89,7 @@
         position: absolute;
         width: fit-content;
         transform: translateX(-50%);
+        color: var(--text-muted);
     }
 
     & .upper-text {
@@ -97,6 +97,7 @@
         width: fit-content;
         font-weight: 500;
         font-size: 16px;
+        color: var(--text-dark);
     }
 
     & .current-upper {

--- a/src/gantt.css
+++ b/src/gantt.css
@@ -246,6 +246,10 @@
 
         & .bar-label {
             fill: var(--text-light);
+
+            &.big {
+                fill: var(--text-dark);
+            }
         }
 
         & .handle {

--- a/src/index.js
+++ b/src/index.js
@@ -569,7 +569,6 @@ export default class Gantt {
      * @returns Object containing the x-axis distance and date of the current date, or null if the current date is out of the gantt range.
      */
     computeGridHighlightDimensions(view_mode) {
-
         const today = new Date();
         if (today < this.gantt_start || today > this.gantt_end) return null;
         let diff_in_units = date_utils.diff(
@@ -611,7 +610,6 @@ export default class Gantt {
         if ($today) {
             $today.classList.add('current-date-highlight');
             $today.style.top = +$today.style.top.slice(0, -2) - 4 + 'px';
-
         }
     }
 
@@ -660,26 +658,25 @@ export default class Gantt {
     }
 
     get_dates_to_draw() {
-        let last_date = null;
+        let last_date_info = null;
         const dates = this.dates.map((date, i) => {
-            const d = this.get_date_info(date, last_date, i);
-            last_date = d;
+            console.log('starting', date, last_date_info);
+            const d = this.get_date_info(date, last_date_info, i);
+            last_date_info = d;
             return d;
         });
         return dates;
     }
 
     get_date_info(date, last_date_info) {
-        let last_date = last_date_info
-            ? last_date_info.date
-            : date_utils.add(date, 1, 'day');
+        let last_date = last_date_info ? last_date_info.date : null;
 
         let column_width = this.config.column_width;
 
         const base_pos = {
             x: last_date_info
                 ? last_date_info.base_pos_x + last_date_info.column_width
-                : 0,
+                : 20,
             lower_y: this.options.header_height - 20,
             upper_y: this.options.header_height - 50,
         };
@@ -710,7 +707,7 @@ export default class Gantt {
                     1) /
                     2,
             upper_y: base_pos.upper_y,
-            lower_x: base_pos.x + column_width / 2,
+            lower_x: base_pos.x + column_width / 2 - 20,
             lower_y: base_pos.lower_y,
         };
     }

--- a/src/index.js
+++ b/src/index.js
@@ -235,7 +235,11 @@ export default class Gantt {
             this.config.view_mode.format_string || 'YYYY-MM-DD HH';
 
         this.gantt_start = date_utils.parse(
-            date_utils.format(gantt_start, format_string),
+            date_utils.format(
+                gantt_start,
+                format_string,
+                this.options.language,
+            ),
         );
         this.gantt_start.setHours(0, 0, 0, 0);
         this.gantt_end = date_utils.add(
@@ -570,7 +574,11 @@ export default class Gantt {
         );
         return {
             x: (diff_in_units / this.config.step) * this.config.column_width,
-            date: date_utils.format(today, this.config.view_mode.format_string),
+            date: date_utils.format(
+                today,
+                this.config.view_mode.format_string,
+                this.options.language,
+            ),
         };
     }
 
@@ -869,6 +877,7 @@ export default class Gantt {
             let currentUpper = date_utils.format(
                 date_utils.add(this.gantt_start, daysSinceStart, 'day'),
                 format_str,
+                this.options.language,
             );
             const upperTexts = Array.from(
                 document.querySelectorAll('.upper-text'),

--- a/src/index.js
+++ b/src/index.js
@@ -1054,24 +1054,25 @@ export default class Gantt {
         let odx = dx,
             rem,
             position;
+
         let unit_length = 1;
-        if (this.options.snap_by_day) {
-            const { duration, scale } = date_utils.parse_duration(
-                this.config.view_mode.step,
-            );
+        const default_snap =
+            this.config.view_mode.default_snap || this.options.default_snap;
+        if (default_snap !== 'unit') {
+            const { duration, scale } = date_utils.parse_duration(default_snap);
             unit_length =
-                duration *
-                ({ hour: 1 / 24, week: 7, month: 30, year: 365 }[scale] || 1);
+                date_utils.convert_scales(this.config.view_mode.step, scale) /
+                duration;
         }
 
         rem = dx % (this.config.column_width / unit_length);
+
         position =
             odx -
             rem +
-            (rem < this.config.column_width / unit_length / 2
+            (rem < (this.config.column_width / unit_length) * 2
                 ? 0
                 : this.config.column_width / unit_length);
-
         return position;
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -349,6 +349,7 @@ export default class Gantt {
                 class: 'grid-row',
                 append_to: rows_layer,
             });
+            // FIX
             if (
                 this.options.lines === 'both' ||
                 this.options.lines === 'horizontal'
@@ -750,7 +751,7 @@ export default class Gantt {
                     ? date_utils.format(date, upper_text, this.options.language)
                     : upper_text(date, last_date, this.options.language),
             lower_text:
-                typeof upper_text === 'string'
+                typeof lower_text === 'string'
                     ? date_utils.format(date, lower_text, this.options.language)
                     : lower_text(date, last_date, this.options.language),
             upper_x: base_pos.x + x_pos[`${this.config.view_mode.name}_upper`],

--- a/src/index.js
+++ b/src/index.js
@@ -81,13 +81,13 @@ export default class Gantt {
         // prepare tasks
         this.tasks = tasks
             .map((task, i) => {
-                // invalid flag
-                if (!task.start || !task.end) {
-                    console.error(`task "${task.id}" doesn't have valid dates`);
+                if (!task.start) {
+                    console.error(
+                        `task "${task.id}" doesn't have a start date`,
+                    );
                     return false;
                 }
 
-                // convert to Date objects
                 task._start = date_utils.parse(task.start);
                 if (task.end === undefined && task.duration !== undefined) {
                     task.end = task._start;
@@ -98,6 +98,10 @@ export default class Gantt {
                             date_utils.parse_duration(tmpDuration);
                         task.end = date_utils.add(task.end, duration, scale);
                     });
+                }
+                if (!task.end) {
+                    console.error(`task "${task.id}" doesn't have an end date`);
+                    return false;
                 }
                 task._end = date_utils.parse(task.end);
 

--- a/src/index.js
+++ b/src/index.js
@@ -669,24 +669,9 @@ export default class Gantt {
             lower_y: this.options.header_height - 20,
             upper_y: this.options.header_height - 50,
         };
-        const x_pos = {
-            Hour_lower: column_width / 2,
-            Hour_upper: column_width * 12,
-            'Quarter Day_lower': column_width / 2,
-            'Quarter Day_upper': column_width * 2,
-            'Half Day_lower': column_width / 2,
-            'Half Day_upper': column_width,
-            Day_lower: column_width / 2,
-            Day_upper: column_width / 2,
-            Week_lower: column_width / 2,
-            Week_upper: (column_width * 4) / 2,
-            Month_lower: column_width / 2,
-            Month_upper: column_width / 2,
-            Year_lower: column_width / 2,
-            Year_upper: (column_width * 30) / 2,
-        };
-        let upper_text = this.config.view_mode.upper_text;
-        let lower_text = this.config.view_mode.lower_text;
+
+        const upper_text = this.config.view_mode.upper_text;
+        const lower_text = this.config.view_mode.lower_text;
 
         return {
             date,
@@ -703,9 +688,13 @@ export default class Gantt {
                 typeof lower_text === 'string'
                     ? date_utils.format(date, lower_text, this.options.language)
                     : lower_text(date, last_date, this.options.language),
-            upper_x: base_pos.x + x_pos[`${this.config.view_mode.name}_upper`],
+            upper_x:
+                base_pos.x +
+                (column_width * this.config.view_mode.upper_text_frequency ||
+                    1) /
+                    2,
             upper_y: base_pos.upper_y,
-            lower_x: base_pos.x + x_pos[`${this.config.view_mode.name}_lower`],
+            lower_x: base_pos.x + column_width / 2,
             lower_y: base_pos.lower_y,
         };
     }

--- a/src/index.js
+++ b/src/index.js
@@ -670,8 +670,10 @@ export default class Gantt {
             upper_y: this.options.header_height - 50,
         };
 
-        const upper_text = this.config.view_mode.upper_text;
-        const lower_text = this.config.view_mode.lower_text;
+        let upper_text = this.config.view_mode.upper_text;
+        let lower_text = this.config.view_mode.lower_text;
+        if (!upper_text) upper_text = () => '';
+        if (!lower_text) lower_text = () => '';
 
         return {
             date,


### PR DESCRIPTION
Hard coding for specific views in the `index` file itself has been removed.

This has two major advantages:
1. It's much easier to integrate custom views - #450 - it can just be passed to the `view_modes` option.
2. The codebase is far less convoluted

Along the line, many bugs (partly related to early changes made in this PR, but often existing before it) were fixed, including:
1. Empty tasks no longer raise errors
2. The placement of the ticks was off
3. Today highlighting and weekend highlighting was off.

Enhancements:
1. Better handling - error messages and ignore - for invalid tasks
2. The `snap_by_day` option - allows for snapping by one day instead of the unit length
3. Today (misnomer) highlighting is now not limited to days. Also, the placement of the blue tick indicates the position within the timeframe - in the below pic, it is shortly after noon.
4. `date_utils.diff` is now rounded to two decimal spaces, not floored.
<img width="54" alt="image" src="https://github.com/user-attachments/assets/c03da415-70f3-46e9-858f-5c91e88eab41">

Closes #451, closes #466, closes #405, closes #401
#### Format of a Mode
_Type:_ object
_Keys_:
- `name` - identifier, mandatory.
- `padding` - the duration of time to pad on both sides. Can be either an array of two strings (for left and right respectively) _or_ one string for both. (Refer to date format below). Mandatory.
- `step` - the length of each unit, mandatory.
- `lower_text` - determines how the lower text is formatted. Can either be a string, which will be the date format, _or_ a function that receives 3 parameters - `date, `last_date`, and `language` - and returns the label to be displayed. Optional - defaults to blank string.
- `upper_text` - determines how the upper text is formatted. Optional - defaults to blank string.
- `upper_text_frequency` - determines how often the upper text appears, used to calculate position of upper text. Optional - defaults to `1`.
- `thick_line` - function that receives a date and determines whether that date should have a thick line in the grid. Optional.
- `column_width` - mode specific column width. Optional, defaults to general column width set in `options`.

#### Date format
`frappe-gantt` entirely uses this format now - duration followed by scale without a space, like `1d` for one day or `5h` for five hours. Supported scales: 
- `ms` for millisecond
- `s` for second
- `min` for minute
- `h` for hour
- `d` for day
- `m` for month
- `y` for year