### PR TITLE
fix: on calling update_task, start and end date not being updated

### DIFF
--- a/src/bar.js
+++ b/src/bar.js
@@ -51,6 +51,8 @@ export default class Bar {
         this.invalid = this.task.invalid;
         this.height = this.gantt.options.bar_height;
         this.image_size = this.height - 5;
+        this.task._start = new Date(this.task.start);
+        this.task._end = new Date(this.task.end);
         this.compute_x();
         this.compute_y();
         this.compute_duration();


### PR DESCRIPTION
On calling update_task(id, task), the name and progress of the bars were being updated, but the start and end date remained the same. 

For example: If I tried to update the task like in the code below, I wasn't able to see updates in start and end date of the bar.
gantt.update_task('1', {name: "Task Updated ", progress: 50, start: '2025-01-14', end: '2025-01-31'})

So I wrote a small date assignment update in prepare_values() inside bar.js, to keep the values in sync.
