### PR TITLE
fix: prevent unnecessary bar position updates

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1281,7 +1281,12 @@ export default class Gantt {
 
             bars.forEach((bar) => {
                 const $bar = bar.$bar;
+                const tempdx = $bar.finaldx;
                 $bar.finaldx = this.get_snap_position(dx, $bar.ox);
+
+                //better to update when position of x axis is changed
+                if (tempdx === $bar.finaldx) return;
+
                 this.hide_popup();
                 if (is_resizing_left) {
                     if (parent_bar_id === bar.task.id) {


### PR DESCRIPTION
Only update the bar position when the snap position has actually changed to avoid redundant updates and improve performance.