### PR TITLE
feat: add the possibility to force the chart to start on a specific day of week

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Each object can have the following properties:
 - `upper_text` (date format string _or_ function) - the format for text in upper header. Blank string for none. The function takes in `currentDate`, `previousDate`, and `lang`, and should return a string.
 - `upper_text_frequency` (number) - how often the upper text has a value. Utilized in internal calculation to improve performance.
 - `thick_line` (function) - takes in `currentDate`, returns Boolean determining whether the line for that date should be thicker than the others.
+- `dow_force_start` (number) - if you want the chart to start on a specific day of the week, add this property and the desired value (0 for Sunday, 1 for Monday, 2 for Tuesday, ..., 6 for Saturday). The start date will then be moved backward from 0 to 6 days depending on the initial calculated start date and your input value).
 
 Three other options allow you to override general configuration for this view mode alone:
 - `date_format`

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -79,6 +79,7 @@ const DEFAULT_VIEW_MODES = [
                 : '',
         thick_line: (d) => d.getDate() >= 1 && d.getDate() <= 7,
         upper_text_frequency: 4,
+        dow_force_start:1,
     },
     {
         name: 'Month',

--- a/src/index.js
+++ b/src/index.js
@@ -321,6 +321,17 @@ export default class Gantt {
                 );
             }
         }
+        if (this.config.view_mode.dow_force_start) {
+            let dow_gantt_start = this.gantt_start.getDay();
+            let dow_wanted_start = this.config.view_mode.dow_force_start;
+            if (dow_gantt_start != dow_wanted_start) {
+                this.gantt_start = date_utils.add(
+                    this.gantt_start,
+                    ((this.gantt_start.getDay() + 7 - (this.config.view_mode.dow_force_start % 7)) * (-1)) % 7,
+                    'day',
+                );
+            }
+        }
         this.config.date_format =
             this.config.view_mode.date_format || this.options.date_format;
         this.gantt_start.setHours(0, 0, 0, 0);


### PR DESCRIPTION
You can force the gantt chart to start on a specific day of the week in the view_mode configuration. Documentation updated and default settings for the week view_mode updated to force the chart to start on Monday.
It works by substracting a number of days (0 to 6 days depending of the input value and the initial start date) to the initially calculated start date 

The issue #186 was closed as 'Not planned' but I needed it so I added it and wanted to contribute to the project.

I am not a professional dev, only a hobbyist so I hope the code is not too bad.