### PR TITLE
Adds new options for moving precedences and maintaining the positioning between dependent tasks

### DIFF
--- a/src/defaults.js
+++ b/src/defaults.js
@@ -121,9 +121,11 @@ const DEFAULT_OPTIONS = {
     infinite_padding: true,
     holidays: { 'var(--g-weekend-highlight-color)': 'weekend' },
     ignore: [],
+    maintain_dependency_position : false,
     language: 'en',
     lines: 'both',
     move_dependencies: true,
+    move_precedences: false,
     padding: 18,
     popup: (ctx) => {
         ctx.set_title(ctx.task.name);


### PR DESCRIPTION
In an application for this gantt chart, I need the dependent tasks to be linked. As such, a change to one triggers a change in others. 

Consider the following example where Task B "Write new content" depends on Task A "Redesign website".
![original](https://github.com/user-attachments/assets/6b951ba3-664d-49a1-8db0-27f7d48db0dc)

If Task A is moved, or the ending time is changed, then that should result in Task B moving by the same amount. 
![move_task_a](https://github.com/user-attachments/assets/6f4f9204-1012-4006-a981-ecd04b5b2916)
![extend_task_a](https://github.com/user-attachments/assets/ec63357c-ad22-4c61-b2ef-858137f7a240)

Also, the precedent tasks are important. If Task B was moved or the start time was changed, the Task A should ,pve by the same amount.
![move_task_b](https://github.com/user-attachments/assets/e31a6374-6fed-45dc-9541-bac231c5b69d)
![extend_task_b](https://github.com/user-attachments/assets/f6b1aee7-ea47-4593-96bc-d389513df7f5)


To this end, this PR introduces two new parameters: `move_precedences` and `maintain_dependency_position`. 
- If `move_precedence` is set to `true`, then the precedent tasks are moved in the same way that the dependent tasks were moved previously. 
- The `maintain_dependency_position` parameter ensures that any change to tasks results in a move in the dependent tasks.
- If both are set to `true`, the changes in the dependent task start time will cause a movement in the preceding task.