### PR TITLE
Adds option for displaying arrows for dependencies

### DIFF
--- a/src/defaults.js
+++ b/src/defaults.js
@@ -115,6 +115,7 @@ const DEFAULT_OPTIONS = {
     container_height: 'auto',
     column_width: null,
     date_format: 'YYYY-MM-DD HH:mm',
+    display_arrows : true,
     upper_header_height: 45,
     lower_header_height: 30,
     snap_at: null,

--- a/src/index.js
+++ b/src/index.js
@@ -861,6 +861,7 @@ export default class Gantt {
 
     make_arrows() {
         this.arrows = [];
+        if (!this.options.display_arrows) return;
         for (let task of this.tasks) {
             let arrows = [];
             arrows = task.dependencies


### PR DESCRIPTION
Adds a parameter for displaying arrows for dependencies. Currently, arrows are always display is there is a dependency relationship. However, it can improve readability if the arrows could be removed.

The option is called `display_arrows` and is set to `true` by default.

With arrows
![with_arrows](https://github.com/user-attachments/assets/ce3f093f-0791-421a-be17-456c839f719a)

Without arrows
![no_arrows](https://github.com/user-attachments/assets/b34b3668-a59d-466e-8bf8-e77db8243b25)
