### PR TITLE
Adds functionality to move tasks between rows

### DIFF
--- a/src/arrow.js
+++ b/src/arrow.js
@@ -24,19 +24,11 @@ export default class Arrow {
         start_x -= 10;
 
         let start_y =
-            this.gantt.config.header_height +
-            this.gantt.options.bar_height +
-            (this.gantt.options.padding + this.gantt.options.bar_height) *
-                this.from_task.task._index +
-            this.gantt.options.padding / 2;
+            this.from_task.$bar.getY() + this.gantt.options.bar_height
 
         let end_x = this.to_task.$bar.getX() - 13;
         let end_y =
-            this.gantt.config.header_height +
-            this.gantt.options.bar_height / 2 +
-            (this.gantt.options.padding + this.gantt.options.bar_height) *
-                this.to_task.task._index +
-            this.gantt.options.padding / 2;
+            this.to_task.$bar.getY() + this.gantt.options.bar_height / 2;
 
         const from_is_below_to =
             this.from_task.task._index > this.to_task.task._index;

--- a/src/index.js
+++ b/src/index.js
@@ -1088,11 +1088,13 @@ export default class Gantt {
             if (e.target.classList.contains('grid-row')) this.unselect_all();
         };
 
-        let pos = 0;
+        let posx = 0;
+        let posy = 0;
         $.on(this.$svg, 'mousemove', '.bar-wrapper, .handle', (e) => {
             if (
                 this.bar_being_dragged === false &&
-                Math.abs((e.offsetX || e.layerX) - pos) > 10
+                (Math.abs((e.offsetX || e.layerX) - posx) > 10 ||
+                 Math.abs((e.offsetY || e.layerY) - posy) > 10)
             )
                 this.bar_being_dragged = true;
         });
@@ -1127,7 +1129,8 @@ export default class Gantt {
             bars = ids.map((id) => this.get_bar(id));
 
             this.bar_being_dragged = false;
-            pos = x_on_start;
+            posx = x_on_start;
+            posy = y_on_start;
 
             bars.forEach((bar) => {
                 const $bar = bar.$bar;
@@ -1135,6 +1138,7 @@ export default class Gantt {
                 $bar.oy = $bar.getY();
                 $bar.owidth = $bar.getWidth();
                 $bar.finaldx = 0;
+                $bar.finaldy = 0;
             });
         });
 
@@ -1278,6 +1282,7 @@ export default class Gantt {
         $.on(this.$svg, 'mousemove', (e) => {
             if (!action_in_progress()) return;
             const dx = (e.offsetX || e.layerX) - x_on_start;
+            const dy = (e.offsetY || e.layerY) - y_on_start;
 
             bars.forEach((bar) => {
                 const $bar = bar.$bar;
@@ -1305,7 +1310,11 @@ export default class Gantt {
                     !this.options.readonly &&
                     !this.options.readonly_dates
                 ) {
-                    bar.update_bar_position({ x: $bar.ox + $bar.finaldx });
+                    $bar.finaldy = this.get_snap_row_position(dy, $bar.oy);
+                    bar.update_bar_position({
+                        x: $bar.ox + $bar.finaldx,
+                        y: $bar.oy + $bar.finaldy
+                    });
                 }
             });
         });
@@ -1335,6 +1344,7 @@ export default class Gantt {
 
     bind_bar_progress() {
         let x_on_start = 0;
+        let y_on_start = 0;
         let is_resizing = null;
         let bar = null;
         let $bar_progress = null;
@@ -1464,6 +1474,21 @@ export default class Gantt {
                 final_pos -= this.config.column_width * drn;
         }
         return final_pos - ox;
+    }
+
+    get_snap_row_position(dy, oy) {
+        let snap_height = this.options.bar_height + this.options.padding;
+        const rem = dy % snap_height;
+
+        let final_dy =
+            dy -
+            rem +
+            (rem < snap_height * 2
+                ? 0
+                : snap_height);
+        let final_pos = oy + final_dy;
+
+        return final_pos - oy;
     }
 
     get_ignored_region(pos, drn = 1) {


### PR DESCRIPTION
A use case that I have benefits from the movement of tasks between rows. An example situation could be that one would like to reorder the tasks based on a different priority. Alternatively, if the rows correspond to group, as introduced by #528, it may be desired to move tasks between the groups.

This PR allows for movement of the bars in the `y` direction. If the user moves the bar up or down, it will snap to the nearest row.

This PR doesn't introduce any new parameters, so the movement in the `y` direction is enabled by default.