### PR TITLE
fix: edit progress

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1335,6 +1335,7 @@ export default class Gantt {
 
     bind_bar_progress() {
         let x_on_start = 0;
+        let y_on_start = 0;
         let is_resizing = null;
         let bar = null;
         let $bar_progress = null;


### PR DESCRIPTION
when edit the progress, the console throw "Cannot read properties" Error