### PR TITLE
fix(bar.js): 修复数组类型自定义类名处理逻辑

### DIFF
--- a/src/bar.js
+++ b/src/bar.js
@@ -12,7 +12,9 @@ export default class Bar {
     refresh() {
         this.bar_group.innerHTML = '';
         this.handle_group.innerHTML = '';
-        if (this.task.custom_class) {
+        if (Array.isArray(this.task.custom_class)) {
+            this.group.classList.add(...this.task.custom_class);
+        } else if (this.task.custom_class) {
             this.group.classList.add(this.task.custom_class);
         } else {
             this.group.classList = ['bar-wrapper'];


### PR DESCRIPTION
处理任务自定义类名时，增加对数组类型的支持，确保类名正确添加到组元素上