### PR TITLE
feat: add custom_weekends option to support dynamic weekend logic (closes #557)

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,6 +137,17 @@
                             >Show weekends</label
                         >
                     </div>
+                    <div class="form-check form-switch">
+                        <input
+                            class="form-check-input"
+                            type="checkbox"
+                            role="switch"
+                            id="custom-weekends"
+                        />
+                        <label class="form-check-label" for="custom-weekends"
+                            >Custom weekends</label
+                        >
+                    </div>
                 </div>
                 <div class="chart col-md-9" id="holidays"></div>
             </div>
@@ -597,6 +608,11 @@
                             { '#a3e635': HOLIDAYS, '#bfdbfe': 'weekend' },
                             { '#a3e635': HOLIDAYS, '#bfdbfe': [] },
                         ],
+                        'custom-weekends': [
+                            'custom_weekends',
+                            (d) => d.getDay() === 6 || d.getDay() === 5,
+                            (d) => d.getDay() === 0 || d.getDay() === 6,
+                        ]
                     },
                 ],
                 [

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -155,6 +155,7 @@ const DEFAULT_OPTIONS = {
     view_mode: 'Day',
     view_mode_select: false,
     view_modes: DEFAULT_VIEW_MODES,
+    custom_weekends: (d) => d.getDay() === 0 || d.getDay() === 6,
 };
 
 export { DEFAULT_OPTIONS, DEFAULT_VIEW_MODES };

--- a/src/index.js
+++ b/src/index.js
@@ -580,7 +580,7 @@ export default class Gantt {
         for (let color in this.options.holidays) {
             let check_highlight = this.options.holidays[color];
             if (check_highlight === 'weekend')
-                check_highlight = (d) => d.getDay() === 0 || d.getDay() === 6;
+                check_highlight = this.options.custom_weekends;
             let extra_func;
 
             if (typeof check_highlight === 'object') {


### PR DESCRIPTION
> Closes #557

Background
Some regions (e.g., Middle Eastern countries) observe weekends on **Friday and Saturday** instead of the default **Saturday and Sunday**. Currently, this behavior is hardcoded.

What's new
This PR introduces a new option:

``` javascript
custom_weekends?: (date: Date) => boolean
```

Accepts a function that takes a Date and returns true if the date is considered a weekend.

Default behavior:

``` javascript
(d: Date) => d.getDay() === 0 || d.getDay() === 6 // Sunday or Saturday
```

Example
If your weekend is Friday and Saturday, you can configure:

``` javascript
custom_weekends: (d) => d.getDay() === 5 || d.getDay() === 6
```

This gives full flexibility to handle both standard and non-standard weekend logic.

Let me know if you'd like any additional changes or documentation updates!