### PR TITLE
fix: correct typo in ignore option assignment

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -96,7 +96,7 @@ export default class Gantt {
 
         if (typeof this.options.ignore !== 'function') {
             if (typeof this.options.ignore === 'string')
-                this.options.ignore = [this.options.ignord];
+                this.options.ignore = [this.options.ignore];
             for (let option of this.options.ignore) {
                 if (typeof option === 'function') {
                     this.config.ignored_function = option;


### PR DESCRIPTION
## Summary of Fix

Fixed a bug where, if the `ignore` option was provided as a string (e.g., ignore: '2025-09-18'), it was incorrectly converted to an array using a non-existent property (`this.options.ignord`). The code now correctly wraps `this.options.ignore` in an array:

## Why the Bug Was Not Previously Detected

In the demo, the `ignore` option is always passed as an array, so this code path was never executed and the bug went unnoticed until now. With this fix, passing a string to the `ignore` option will work as intended.