### PR TITLE
fix a recursive dependency

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1443,7 +1443,7 @@ export default class Gantt {
             }, []);
 
             out = out.concat(deps);
-            to_process = deps.filter((d) => !to_process.includes(d));
+            to_process = deps.filter((d) => !to_process.includes(d) && !out.includes(d));
         }
 
         return out.filter(Boolean);


### PR DESCRIPTION
<img width="1181" height="487" alt="image" src="https://github.com/user-attachments/assets/c8fc7413-0546-4d9f-a592-00de90599122" />
Hi, I found a recursive bug in this case that causes the browser tab to freeze when the user hovers over a task node.
