### PR TITLE
feat: support CSS values for container_height option (#587)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -99,11 +99,13 @@ export default class Gantt {
         };
         for (let name in CSS_VARIABLES) {
             let setting = this.options[CSS_VARIABLES[name]];
-            if (setting !== 'auto')
-                this.$container.style.setProperty(
-                    '--gv-' + name,
-                    setting + 'px',
-                );
+            if (setting !== 'auto') {
+                // If setting is a string (e.g., '100%', 'calc(100vh - 200px)'), use as-is
+                // Otherwise, append 'px' for numeric values
+                const value =
+                    typeof setting === 'string' ? setting : setting + 'px';
+                this.$container.style.setProperty('--gv-' + name, value);
+            }
         }
 
         this.config = {


### PR DESCRIPTION
## Summary

This PR implements smart type detection for the `container_height` option, allowing CSS string values like percentages, `calc()`, viewport units, and other CSS values in addition to numeric pixel values.

**Fixes #587**

## Problem

The `container_height` option previously only accepted numeric pixel values or `'auto'`. When users passed CSS string values, they were incorrectly converted:

```javascript
container_height: '100%'              // Resulted in: --gv-grid-height: 100%px (invalid CSS)
container_height: 'calc(100vh - 200px)' // Resulted in: calc(100vh - 200px)px (invalid CSS)
```

This made it difficult to create responsive, viewport-constrained Gantt charts with proper scrolling behavior.

## Solution

The fix uses smart type detection:
- **String values** → used as-is (e.g., `'100%'` → `'100%'`)
- **Numeric values** → append `'px'` as before (e.g., `600` → `'600px'`)

## Usage

```javascript
new Gantt(container, tasks, {
    container_height: '100%',                    // ✅ Sets: --gv-grid-height: 100%
    container_height: 'calc(100vh - 200px)',     // ✅ Sets: --gv-grid-height: calc(100vh - 200px)
    container_height: '50vh',                    // ✅ Sets: --gv-grid-height: 50vh
    container_height: 600,                       // ✅ Still works: --gv-grid-height: 600px
});
```

## Backward Compatibility

- ✅ Numeric values still work exactly as before
- ✅ `'auto'` value behavior unchanged
- ✅ No breaking changes