### PR TITLE
fix(gantt): properly cleanup mouseup event and destroy component

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -41,7 +41,7 @@ export default class Gantt {
         } else {
             throw new TypeError(
                 'Frappe Gantt only supports usage of a string CSS selector,' +
-                    " HTML DOM element or SVG DOM element for the 'element' parameter",
+                " HTML DOM element or SVG DOM element for the 'element' parameter",
             );
         }
 
@@ -415,10 +415,10 @@ export default class Gantt {
         const grid_width = this.dates.length * this.config.column_width;
         const grid_height = Math.max(
             this.config.header_height +
-                this.options.padding +
-                (this.options.bar_height + this.options.padding) *
-                    this.tasks.length -
-                10,
+            this.options.padding +
+            (this.options.bar_height + this.options.padding) *
+            this.tasks.length -
+            10,
             this.options.container_height !== 'auto'
                 ? this.options.container_height
                 : 0,
@@ -975,7 +975,7 @@ export default class Gantt {
         this.current_date = date_utils.add(
             this.gantt_start,
             (this.$container.scrollLeft + $el.clientWidth) /
-                this.config.column_width,
+            this.config.column_width,
             this.config.unit,
         );
         current_upper = this.config.view_mode.upper_text(
@@ -1000,13 +1000,13 @@ export default class Gantt {
         let current = new Date(),
             el = this.$container.querySelector(
                 '.date_' +
-                    sanitize(
-                        date_utils.format(
-                            current,
-                            this.config.date_format,
-                            this.options.language,
-                        ),
+                sanitize(
+                    date_utils.format(
+                        current,
+                        this.config.date_format,
+                        this.options.language,
                     ),
+                ),
             );
 
         // safety check to prevent infinite loop
@@ -1015,13 +1015,13 @@ export default class Gantt {
             current = date_utils.add(current, -1, this.config.unit);
             el = this.$container.querySelector(
                 '.date_' +
-                    sanitize(
-                        date_utils.format(
-                            current,
-                            this.config.date_format,
-                            this.options.language,
-                        ),
+                sanitize(
+                    date_utils.format(
+                        current,
+                        this.config.date_format,
+                        this.options.language,
                     ),
+                ),
             );
             c++;
         }
@@ -1178,9 +1178,9 @@ export default class Gantt {
                 if (
                     !extended &&
                     e.currentTarget.scrollWidth -
-                        (e.currentTarget.scrollLeft +
-                            e.currentTarget.clientWidth) <=
-                        trigger
+                    (e.currentTarget.scrollLeft +
+                        e.currentTarget.clientWidth) <=
+                    trigger
                 ) {
                     let old_scroll_left = e.currentTarget.scrollLeft;
                     extended = true;
@@ -1211,7 +1211,7 @@ export default class Gantt {
             this.current_date = date_utils.add(
                 this.gantt_start,
                 (e.currentTarget.scrollLeft / this.config.column_width) *
-                    this.config.step,
+                this.config.step,
                 this.config.unit,
             );
 
@@ -1229,7 +1229,7 @@ export default class Gantt {
                 this.gantt_start,
                 ((e.currentTarget.scrollLeft + $el.clientWidth) /
                     this.config.column_width) *
-                    this.config.step,
+                this.config.step,
                 this.config.unit,
             );
             current_upper = this.config.view_mode.upper_text(
@@ -1326,14 +1326,19 @@ export default class Gantt {
             });
         });
 
-        document.addEventListener('mouseup', () => {
+        this.cleanup_bar_events = () => {
+            document.removeEventListener('mouseup', this.on_mouse_up);
+        };
+        this.on_mouse_up = () => {
             is_dragging = false;
             is_resizing_left = false;
             is_resizing_right = false;
             this.$container
                 .querySelector('.visible')
                 ?.classList?.remove?.('visible');
-        });
+        };
+
+        document.addEventListener('mouseup', this.on_mouse_up);
 
         $.on(this.$svg, 'mouseup', (e) => {
             this.bar_being_dragged = null;
@@ -1347,6 +1352,17 @@ export default class Gantt {
         });
 
         this.bind_bar_progress();
+    }
+
+    destroy() {
+        if (this.cleanup_bar_events) {
+            this.cleanup_bar_events();
+        }
+        // Cleanup wrapper elements
+        this.$container.innerHTML = '';
+        this.$svg.innerHTML = '';
+        // Remove class from SVG if it was added
+        this.$svg.classList.remove('gantt');
     }
 
     bind_bar_progress() {


### PR DESCRIPTION
🐛 Problem

The Gantt component was attaching global listeners (document.addEventListener('mouseup')) using anonymous functions, making it impossible to remove them when the component was destroyed or re-created.

This caused:

- Accumulation of listeners over time
- Unpredictable behavior (drag getting stuck, events firing multiple times)
- Memory leaks
- Blank pages in some cases (SPA)

✅ Solution

- Added a destroy() method to properly clean up:
- Event listeners
- DOM elements (container & SVG)
- CSS classes
- Refactored mouseup handling:
- Used a referenced handler (this.on_mouse_up)
- Explicit removal of the listener via removeEventListener
- Centralized cleanup in cleanup_bar_events

🧪 Impact / Outcome

- Correct lifecycle management of the Gantt component
- Memory leaks fixed
- Stable behavior during drag/resize
- Component can now safely be reset or destroyed

🔍 Notes

- No visual changes
- No breaking changes
- Internal improvement for stability and maintainability