### PR TITLE
fix: unit mismatch in expected progress calculation

### DIFF
--- a/src/bar.js
+++ b/src/bar.js
@@ -577,22 +577,18 @@ export default class Bar {
     }
 
     compute_expected_progress() {
-        const total_task_hours = date_utils.diff(
-            this.task._end,
-            this.task._start,
-            'hour',
-        );
-        const hours_passed = date_utils.diff(
-            date_utils.now(),
-            this.task._start,
-            'hour',
-        );
+        this.expected_progress =
+            date_utils.diff(
+                date_utils.now(),
+                this.task._start,
+                this.gantt.config.unit,
+            ) / this.gantt.config.step;
         const safe_progress = Math.max(
             0,
-            Math.min(hours_passed, total_task_hours),
+            Math.min(this.expected_progress, this.duration),
         );
         this.expected_progress =
-            total_task_hours > 0 ? (safe_progress * 100) / total_task_hours : 0;
+            this.duration > 0 ? (safe_progress * 100) / this.duration : 0;
     }
 
     compute_x() {

--- a/src/bar.js
+++ b/src/bar.js
@@ -94,6 +94,10 @@ export default class Bar {
     }
 
     prepare_expected_progress_values() {
+        if (!this.gantt.options.show_expected_progress) {
+            this.expected_progress_width = 0;
+            return;
+        }
         this.compute_expected_progress();
         this.expected_progress_width =
             this.gantt.options.column_width *
@@ -573,15 +577,22 @@ export default class Bar {
     }
 
     compute_expected_progress() {
+        const total_task_hours = date_utils.diff(
+            this.task._end,
+            this.task._start,
+            'hour',
+        );
+        const hours_passed = date_utils.diff(
+            date_utils.now(),
+            this.task._start,
+            'hour',
+        );
+        const safe_progress = Math.max(
+            0,
+            Math.min(hours_passed, total_task_hours),
+        );
         this.expected_progress =
-            date_utils.diff(date_utils.today(), this.task._start, 'hour') /
-            this.gantt.config.step;
-        this.expected_progress =
-            ((this.expected_progress < this.duration
-                ? this.expected_progress
-                : this.duration) *
-                100) /
-            this.duration;
+            total_task_hours > 0 ? (safe_progress * 100) / total_task_hours : 0;
     }
 
     compute_x() {


### PR DESCRIPTION
Related Issue: #574

This PR addresses the core unit-mismatch logic for the expected progress bar. While this resolves the primary bug in Day View, the Month View still exhibits some coordinate drift. I am linking the issue here for context but not marking it as "closed" yet, as further work on the library's internal grid mapping may be required. I'm not yet skilled enough to resolve the Month View's coordinate drift on my own, so I’d really appreciate any guidance or help to address it.